### PR TITLE
update prop types to match react native

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -16,7 +16,7 @@ var systemButtonOpacity = 0.2;
 var Button = React.createClass({
   propTypes: {
     ...TouchableOpacity.propTypes,
-    containerStyle: TouchableOpacity.propTypes.style,
+    containerStyle: View.propTypes.style,
     disabled: PropTypes.bool,
     style: Text.propTypes.style,
     styleDisabled: Text.propTypes.style,


### PR DESCRIPTION
There is no key TouchableHighlight.propTypes.style anymore. Facebook is using View.propTypes.style instead. [Relevant line](https://github.com/facebook/react-native/blob/33d8db599ef8eb85dc27150e04c71719be6ffd26/Libraries/Components/Touchable/TouchableHighlight.js#L81l)
