### PR TITLE
Add accessibilityTraits to support screen readers

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -31,7 +31,13 @@ export default class Button extends Component {
     }
 
     return (
-      <TouchableOpacity {...touchableProps} testID={this.props.testID} style={this.props.containerStyle}>
+      <TouchableOpacity
+        {...touchableProps}
+        testID={this.props.testID}
+        style={this.props.containerStyle}
+        accessibilityTraits="button"
+        accessibilityComponentType="button"
+      >
         {this._renderGroupedChildren()}
       </TouchableOpacity>
     );


### PR DESCRIPTION
Using `accessibilityTraits="button"` allows screen readers like Voiceover or TalkBack to behave more appropriately. See the [React Native](https://facebook.github.io/react-native/docs/accessibility.html) or [Apple](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/iPhoneAccessibility/Making_Application_Accessible/Making_Application_Accessible.html#//apple_ref/doc/uid/TP40008785-CH102-SW7) guides for more info.
