### PR TITLE
Fix import for PropTypes

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -1,4 +1,6 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component} from 'react';
+import PropTypes from 'prop-types';
+
 import {
   StyleSheet,
   Text,


### PR DESCRIPTION
Now imported from 'prop-types', not 'react'.