### PR TITLE
Add styleChildrenGroup prop

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -22,6 +22,7 @@ export default class Button extends Component {
     disabled: PropTypes.bool,
     style: Text.propTypes.style,
     styleDisabled: Text.propTypes.style,
+    childGroupStyle: ViewPropTypes.style,
   };
 
   render() {
@@ -64,6 +65,10 @@ export default class Button extends Component {
       this.props.style,
       disabled ? this.props.styleDisabled : null,
     ];
+    let childGroupStyle = [
+      styles.group,
+      this.props.childGroupStyle,
+    ];
 
     let children = coalesceNonElementChildren(this.props.children, (children, index) => {
       return (
@@ -79,7 +84,7 @@ export default class Button extends Component {
       case 1:
         return children[0];
       default:
-        return <View style={styles.group}>{children}</View>;
+        return <View style={childGroupStyle}>{children}</View>;
     }
   }
 


### PR DESCRIPTION
Add an optional styleChildrenGroup prop that lets you change the style of the children container that is rendered when there are 2+ children.

The motivation behind this is to change the flexbox justifyContent parameter, so that children are grouped together and centered instead of using the default of space-between.