### PR TITLE
Fix disabled state

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -48,6 +48,7 @@ export default class Button extends Component {
       <TouchableOpacity
         {...touchableProps}
         testID={this.props.testID}
+        disabled={this.props.disabled}
         style={containerStyle}
         accessibilityLabel={this.props.accessibilityLabel}
         accessibilityTraits="button"


### PR DESCRIPTION
If you create a button with disabled={true} and then set it to disabled={false} the opacity doesn't change (the container style still looks disabled because the opacity is still applied).

Passing the disabled prop to the touchable opacity component fixes this issue.

Before the fix:
![before](https://user-images.githubusercontent.com/1247834/52441555-f2775280-2aee-11e9-80c7-e5c98a5af457.gif)

After the fix:

![after](https://user-images.githubusercontent.com/1247834/52440954-66186000-2aed-11e9-9588-a60c19ac6f48.gif)