### PR TITLE
Update accessibility to use cross platform props accessibilityRole

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -50,7 +50,7 @@ export default class Button extends Component {
         testID={this.props.testID}
         style={containerStyle}
         accessibilityLabel={this.props.accessibilityLabel}
-        accessibilityRole={"button"}>
+        accessibilityRole="button">
         {this._renderGroupedChildren()}
       </TouchableOpacity>
     );

--- a/Button.js
+++ b/Button.js
@@ -50,8 +50,7 @@ export default class Button extends Component {
         testID={this.props.testID}
         style={containerStyle}
         accessibilityLabel={this.props.accessibilityLabel}
-        accessibilityTraits="button"
-        accessibilityComponentType="button">
+        accessibilityRole={"button"}>
         {this._renderGroupedChildren()}
       </TouchableOpacity>
     );


### PR DESCRIPTION
Based on the latest react native 0.59 update. It seems like `accessibilityTraits (iOS)` and `accessibilityComponentType (Android)` are getting deprecated for accessibility.

Check source:
https://facebook.github.io/react-native/docs/accessibility
<img width="760" alt="Screen Shot 2019-05-01 at 9 09 35 PM" src="https://user-images.githubusercontent.com/20803485/57082481-cff76e80-6cc4-11e9-9495-cdb5042089fe.png">

