### PR TITLE
Fix #87

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -64,7 +64,7 @@ export default class Button extends Component {
         : TouchableNativeFeedback.SelectableBackground();
 
       let padding = 0;
-      if (containerStyle[0].padding) {
+      if (containerStyle[0] && containerStyle[0].padding) {
         padding = containerStyle[0].padding;
         const fixedStyle = Object.assign({}, containerStyle[0], {padding: 0});
         containerStyle[0] = fixedStyle;


### PR DESCRIPTION
Android version assumed that `containerStyle` is always specified, which is not correct. Added additional check that object exists.