### PR TITLE
Add a props table to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,78 @@ export default class ExampleComponent extends Component {
 
 ```
 
+## Props
+
+<table>
+  <tr>
+    <th>Prop</th>
+    <th>Required</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>accessibilityLabel</td>
+    <td>No</td>
+    <td>String</td>
+    <td>VoiceOver will read this string when a user selects the associated element.</td>
+  </tr>
+  <tr>
+    <td>allowFontScaling</td>
+    <td>No</td>
+    <td>Bool</td>
+    <td>Specifies whether fonts should scale to respect Text Size accessibility settings. </td>
+  </tr>
+  
+  <tr>
+    <td>Disabled</td>
+    <td>No</td>
+    <td>Bool</td>
+    <td>Disables the button</td>
+  </tr>
+  <tr>
+    <td>Style</td>
+    <td>No</td>
+    <td>View Style Prop</td>
+    <td>The style for the button</td>
+  </tr>
+  <tr>
+    <td>styleDisabled</td>
+    <td>No</td>
+    <td>View Style Prop</td>
+    <td>The style for the disabled button</td>
+  </tr>
+  <tr>
+    <td>containerStyle</td>
+    <td>No</td>
+    <td>View Style Prop</td>
+    <td>The style for the container</td>
+  </tr>
+  <tr>
+    <td>disabledContainerStyle</td>
+    <td>No</td>
+    <td>View Style Prop</td>
+    <td>The style for the container when the button is disabled</td>
+  </tr>
+  <tr>
+    <td>childGroupStyle</td>
+    <td>No</td>
+    <td>View Style Prop</td>
+    <td>The style for the child views</td>
+  </tr>
+  <tr>
+    <td>androidBackground</td>
+    <td>No</td>
+    <td>Background Prop Type</td>
+    <td>The background for andriod devices.</td>
+  </tr>
+  <tr>
+    <td>onPress</td>
+    <td>No</td>
+    <td>Function</td>
+    <td>Handler to be called when the user taps the button. </td>
+  </tr>
+</table>
+
 ## Container Style
 
 You can make a button with rounded corners like this:


### PR DESCRIPTION
Created a Table in README.md featuring all of the props, prop types, prop requirement, and descriptions

Screenshot: 

![Screenshot 2020-11-26 at 00 23 40](https://user-images.githubusercontent.com/67103516/100254755-ad4f3980-2f7d-11eb-9ecb-15fe42541871.png)


